### PR TITLE
docs: add project overview and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,41 @@
-# React + TypeScript + Vite
+# Product Image Studio
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A data‑driven layout engine for generating marketing and product mockups from JSON scene files.
 
-Currently, two official plugins are available:
+## Tech Stack
+- React 19 + TypeScript
+- Vite
+- Tailwind CSS 4
+- Ajv for JSON Schema validation
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Project Structure
 ```
+public/          static assets and `sceneData` JSON files
+schemas/         JSON Schemas for scenes
+src/             React components and application code
+└── components/  Scene-specific components
+```
+Additional reference docs live under `docs/`:
+- [SCENES.md](docs/SCENES.md) – schema/component specs
+- [THEMES.md](docs/THEMES.md) – theme assets and tokens
+- [EXAMPLES.md](docs/EXAMPLES.md) – sample `sceneData` files
+- [USAGE.md](docs/USAGE.md) – manual & GPT workflow
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Planned Scenes
+- Hero banner
+- Notion-style dashboard
+- Upcoming layouts like calendars, kanban boards, and more
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Style Direction
+Light radial gradients, soft shadows, subtle noise textures, and floating orbs evoke a calm productivity vibe. Inter is the primary typeface and Tailwind tokens drive spacing and color.
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## JSON Format Philosophy
+Each scene is defined by a JSON file in `public/sceneData/` and validated against a schema in `/schemas/`. Components read typed data, enabling predictable rendering and AI-assisted generation.
+
+## Scripts
+```bash
+npm install    # install dependencies
+npm run dev    # start dev server
+npm run build  # build for production
+npm run lint   # run ESLint
 ```

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,0 +1,47 @@
+# Scene Data Examples
+
+The `public/sceneData/` folder contains JSON files that feed the layout engine. Each file matches a schema in `/schemas/`.
+
+## Hero
+```json
+{
+  "type": "hero",
+  "title": "Welcome to Product Image Studio",
+  "subtitle": "Your personal visual engine",
+  "backgroundColor": "#fef9f4",
+  "image": {
+    "src": "https://placehold.co/800x400?text=Mock+Screenshot",
+    "alt": "Example template screenshot"
+  }
+}
+```
+
+## Notion Dashboard
+```json
+{
+  "type": "notionDashboard",
+  "mainHeading": "Plan without burnout",
+  "subHeading": "This dashboard helps you pace the journey",
+  "browserUrl": "mondaychick.co",
+  "dashboardTitle": "My Weekly Planner",
+  "sections": [
+    {
+      "title": "This Week's Focus",
+      "emoji": "",
+      "items": [
+        { "text": "Review project roadmap", "checked": true },
+        { "text": "Schedule team check-ins", "checked": false },
+        { "text": "Prepare presentation slides", "checked": false }
+      ]
+    },
+    {
+      "title": "Energy Management",
+      "emoji": "",
+      "items": [
+        { "text": "Morning meditation (15 min)", "checked": true },
+        { "text": "Take lunch break away from desk", "checked": false }
+      ]
+    }
+  ]
+}
+```

--- a/docs/SCENES.md
+++ b/docs/SCENES.md
@@ -1,0 +1,30 @@
+# Scene Specifications
+
+This project renders marketing scenes from JSON files. Each scene uses a JSON Schema for validation and a dedicated React component.
+
+## Hero
+- **Schema**: `schemas/hero.schema.json`
+- **Component**: `src/components/Hero.tsx`
+- **Purpose**: Landing page hero with headline, subtitle, and screenshot.
+- **Fields**:
+  - `type` (must be `"hero"`)
+  - `title`
+  - `subtitle`
+  - `backgroundColor`
+  - `image` object with `src` and `alt`
+- **Example**: `public/sceneData/hero.json`
+
+## Notion Dashboard
+- **Schema**: `schemas/notionDashboard.schema.json`
+- **Component**: `src/components/NotionDashboard.tsx`
+- **Purpose**: Notion-style task board inside a browser mockup.
+- **Fields**:
+  - `type` (must be `"notionDashboard"`)
+  - `mainHeading`, `subHeading`
+  - `browserUrl`, `dashboardTitle`
+  - `sections[]` → `{ title, emoji, items[] }`
+  - `items[]` → `{ text, checked }`
+- **Example**: `public/sceneData/notionDashboard.json`
+
+## Planned Scenes
+Additional layouts like calendars, kanban boards, and code snippets will be added as new schemas and components.

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -1,0 +1,13 @@
+# Theme Resources
+
+Visual style is driven by soft gradients, subtle noise, and floating orbs reminiscent of productivity dashboards.
+
+## Assets
+- **SVG Packs**: Place grunge overlays and decorative shapes under `public/assets/`.
+- **Fonts**: The project uses [Inter](https://rsms.me/inter) as the primary typeface.
+- **Tailwind Tokens**: Color and spacing tokens live in `tailwind.config.js`. Extend this file when adding new themes.
+
+## Guidelines
+- Keep backgrounds light with radial gradients.
+- Apply a low‑opacity noise texture for depth.
+- Use Tailwind utility classes first; fall back to CSS when necessary.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,24 @@
+# Usage
+
+## Local Development
+```bash
+npm install
+npm run dev
+```
+Visit http://localhost:5173 to view the demo.
+
+## Generating a Scene with GPT
+1. Ask GPT to produce a scene JSON and matching schema following the examples in `/schemas/`.
+2. Save the schema under `schemas/` and the data file under `public/sceneData/`.
+3. Create a React component in `src/components/` that consumes the scene data.
+4. Validate all scenes:
+```bash
+npm run lint
+# (optional) npm run validate   # if a validation script is added
+```
+
+## Production Build
+```bash
+npm run build
+npm run preview
+```


### PR DESCRIPTION
## Summary
- replace template README with project overview, scene plans, style direction, and JSON schema philosophy
- add SCENES, THEMES, EXAMPLES, and USAGE docs for collaborators and AI tools

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895f0d5683c832a83cd4e81bb9ca3f6