### PR TITLE
docs: add scene and visuals guides

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,47 +1,107 @@
-# Scene Data Examples
+# Examples
 
-The `public/sceneData/` folder contains JSON files that feed the layout engine. Each file matches a schema in `/schemas/`.
+This document contains real, minimal, and complete example JSON configurations for each available scene type. These examples are used to:
 
-## Hero
+* Verify JSON schema and validator behavior
+* Guide GPTs in generating scene data
+* Help users understand the expected structure
+
+---
+
+## Hero Scene
+
 ```json
 {
   "type": "hero",
-  "title": "Welcome to Product Image Studio",
-  "subtitle": "Your personal visual engine",
-  "backgroundColor": "#fef9f4",
+  "backgroundColor": "#f0f9f4",
+  "title": "Your Goals, Visualized",
+  "subtitle": "Notion templates to help you win the day.",
   "image": {
-    "src": "https://placehold.co/800x400?text=Mock+Screenshot",
-    "alt": "Example template screenshot"
+    "src": "https://example.com/image.png",
+    "alt": "Mockup of dashboard"
   }
 }
 ```
 
-## Notion Dashboard
+---
+
+## Feature Grid Scene
+
 ```json
 {
-  "type": "notionDashboard",
-  "mainHeading": "Plan without burnout",
-  "subHeading": "This dashboard helps you pace the journey",
-  "browserUrl": "mondaychick.co",
-  "dashboardTitle": "My Weekly Planner",
-  "sections": [
+  "type": "featureGrid",
+  "backgroundColor": "#ffffff",
+  "title": "Everything You Need",
+  "features": [
     {
-      "title": "This Week's Focus",
-      "emoji": "",
-      "items": [
-        { "text": "Review project roadmap", "checked": true },
-        { "text": "Schedule team check-ins", "checked": false },
-        { "text": "Prepare presentation slides", "checked": false }
-      ]
+      "icon": "check-circle",
+      "title": "Goal Tracker",
+      "description": "Stay on top of your short- and long-term goals."
     },
     {
-      "title": "Energy Management",
-      "emoji": "",
-      "items": [
-        { "text": "Morning meditation (15 min)", "checked": true },
-        { "text": "Take lunch break away from desk", "checked": false }
-      ]
+      "icon": "calendar",
+      "title": "Habit Logs",
+      "description": "Track your daily routines with ease."
     }
   ]
 }
 ```
+
+---
+
+## Testimonial Scene
+
+```json
+{
+  "type": "testimonial",
+  "backgroundColor": "#fef7f0",
+  "quote": "This template changed how I plan my entire week!",
+  "author": "Lynn R.",
+  "role": "Notion Seller",
+  "avatar": "https://example.com/avatar.png"
+}
+```
+
+---
+
+## Split Layout Scene
+
+```json
+{
+  "type": "splitLayout",
+  "backgroundColor": "#f9f9f9",
+  "title": "Plan. Review. Repeat.",
+  "text": "Each page in this template is designed with intention.",
+  "image": {
+    "src": "https://example.com/side-by-side.png",
+    "alt": "Side-by-side of template sections"
+  },
+  "reverse": false
+}
+```
+
+---
+
+## Image Showcase Scene
+
+```json
+{
+  "type": "imageShowcase",
+  "backgroundColor": "#ffffff",
+  "title": "Visual Walkthrough",
+  "images": [
+    {
+      "src": "https://example.com/ss1.png",
+      "alt": "First dashboard page"
+    },
+    {
+      "src": "https://example.com/ss2.png",
+      "alt": "Second dashboard page"
+    }
+  ]
+}
+```
+
+---
+
+Each of these examples maps directly to a schema file inside `/schemas/` and a component inside `/src/components/`. They can be validated with Ajv and used in prompt recipes.

--- a/docs/SCENES.md
+++ b/docs/SCENES.md
@@ -1,30 +1,149 @@
-# Scene Specifications
+# 📐 Scene Definitions
 
-This project renders marketing scenes from JSON files. Each scene uses a JSON Schema for validation and a dedicated React component.
+This document defines the **structure** and **schema** for each planned scene type. Each scene type has:
 
-## Hero
-- **Schema**: `schemas/hero.schema.json`
-- **Component**: `src/components/Hero.tsx`
-- **Purpose**: Landing page hero with headline, subtitle, and screenshot.
-- **Fields**:
-  - `type` (must be `"hero"`)
-  - `title`
-  - `subtitle`
-  - `backgroundColor`
-  - `image` object with `src` and `alt`
-- **Example**: `public/sceneData/hero.json`
+* A unique JSON schema
+* A matching React component
+* Strict props and render behavior
 
-## Notion Dashboard
-- **Schema**: `schemas/notionDashboard.schema.json`
-- **Component**: `src/components/NotionDashboard.tsx`
-- **Purpose**: Notion-style task board inside a browser mockup.
-- **Fields**:
-  - `type` (must be `"notionDashboard"`)
-  - `mainHeading`, `subHeading`
-  - `browserUrl`, `dashboardTitle`
-  - `sections[]` → `{ title, emoji, items[] }`
-  - `items[]` → `{ text, checked }`
-- **Example**: `public/sceneData/notionDashboard.json`
+All scene data is passed via JSON to ensure compatibility with GPT-driven creation.
 
-## Planned Scenes
-Additional layouts like calendars, kanban boards, and code snippets will be added as new schemas and components.
+---
+
+## ✅ Scene: Hero
+
+**Purpose:** Main splash scene with product name, subtitle, and centered screenshot.
+
+**JSON Structure:**
+
+```json
+{
+  "type": "hero",
+  "backgroundColor": "#f0f9f4",
+  "title": "Product Name",
+  "subtitle": "Your subtitle here",
+  "image": {
+    "src": "https://...",
+    "alt": "..."
+  }
+}
+```
+
+**Props:**
+
+* `backgroundColor`: Hex color string
+* `title`: string
+* `subtitle`: string
+* `image.src`: URL
+* `image.alt`: string
+
+---
+
+## 🪞 Scene: SideBySide
+
+**Purpose:** Two-column layout with text on one side and image on the other.
+
+**JSON Structure:**
+
+```json
+{
+  "type": "sideBySide",
+  "backgroundColor": "#fff",
+  "leftText": "...",
+  "rightImage": {
+    "src": "...",
+    "alt": "..."
+  },
+  "reverse": false
+}
+```
+
+**Props:**
+
+* `leftText`: Markdown allowed
+* `rightImage.src`
+* `rightImage.alt`
+* `reverse`: if true, flips image/text
+
+---
+
+## 💬 Scene: Quote
+
+**Purpose:** Stylish callout with large quote text and attribution
+
+**JSON Structure:**
+
+```json
+{
+  "type": "quote",
+  "quote": "Design is the silent ambassador of your brand.",
+  "author": "Paul Rand",
+  "backgroundPattern": "grunge-01.svg"
+}
+```
+
+**Props:**
+
+* `quote`: large stylized text
+* `author`: caption
+* `backgroundPattern`: local asset name (SVG)
+
+---
+
+## 🖼️ Scene: Gallery
+
+**Purpose:** Grid of 3–6 mockups, each with optional label
+
+**JSON Structure:**
+
+```json
+{
+  "type": "gallery",
+  "images": [
+    { "src": "...", "alt": "...", "caption": "..." },
+    ...
+  ]
+}
+```
+
+**Props:**
+
+* `images[]`: must be between 3–6 items
+* `caption`: optional
+
+---
+
+## 🧠 Scene: FeatureList
+
+**Purpose:** Bullet-style benefits list with checkmarks or icons
+
+**JSON Structure:**
+
+```json
+{
+  "type": "featureList",
+  "title": "Why you'll love it",
+  "features": ["Fast", "Minimal setup", "Beautiful visuals"],
+  "iconStyle": "check" // or "star", "bolt"
+}
+```
+
+**Props:**
+
+* `title`: string
+* `features[]`: list of strings
+* `iconStyle`: preset
+
+---
+
+## Coming Soon
+
+* `testimonialGrid`
+* `pricingBlock`
+* `callToAction`
+
+Each new scene must:
+
+* Have a schema in `schemas/`
+* Be registered in scene loader
+* Be documented in this file

--- a/docs/Schemas.md
+++ b/docs/Schemas.md
@@ -1,0 +1,107 @@
+# Schemas
+
+This document outlines the JSON schema structure for each scene type supported by the Product Image Studio. Each schema ensures strict typing, required fields, and validation logic to keep the rendering predictable and GPT-friendly.
+
+---
+
+## Global Notes
+
+* All scene JSON files must follow a strict schema.
+* Validation is done via AJV before rendering.
+* Each scene has a `type` field as the top-level discriminator.
+* Fields not included in the schema will be ignored during rendering.
+
+---
+
+## hero.schema.json
+
+```json
+{
+  "type": "object",
+  "required": ["type", "title", "subtitle", "image"],
+  "properties": {
+    "type": { "const": "hero" },
+    "backgroundColor": { "type": "string", "format": "color" },
+    "title": { "type": "string" },
+    "subtitle": { "type": "string" },
+    "image": {
+      "type": "object",
+      "required": ["src"],
+      "properties": {
+        "src": { "type": "string", "format": "uri" },
+        "alt": { "type": "string" }
+      }
+    },
+    "textAlign": {
+      "type": "string",
+      "enum": ["left", "center", "right"],
+      "default": "center"
+    },
+    "fontFamily": { "type": "string" },
+    "fontSize": { "type": "number" },
+    "pattern": { "type": "string" },
+    "textColor": { "type": "string", "format": "color" }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## featureGrid.schema.json
+
+*(Planned)*
+
+```json
+{
+  "type": "object",
+  "required": ["type", "title", "features"],
+  "properties": {
+    "type": { "const": "featureGrid" },
+    "title": { "type": "string" },
+    "features": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["title", "description"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "icon": { "type": "string", "format": "uri" }
+        }
+      }
+    },
+    "columns": { "type": "integer", "default": 2 },
+    "backgroundColor": { "type": "string", "format": "color" },
+    "pattern": { "type": "string" }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## callout.schema.json
+
+*(Planned)*
+
+```json
+{
+  "type": "object",
+  "required": ["type", "text"],
+  "properties": {
+    "type": { "const": "callout" },
+    "text": { "type": "string" },
+    "icon": { "type": "string" },
+    "color": { "type": "string", "format": "color" },
+    "textColor": { "type": "string", "format": "color" },
+    "pattern": { "type": "string" },
+    "fontSize": { "type": "number" }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+Additional schemas will follow the same rules: strongly typed, no extraneous properties, and custom visual configuration support (font, color, pattern, etc.).

--- a/docs/VISUALS.md
+++ b/docs/VISUALS.md
@@ -1,0 +1,118 @@
+# VISUALS.md
+
+This document defines the **visual language and theme system** for the Product Image Studio. These assets influence the look and feel of each scene.
+
+---
+
+## 🎨 Theme Strategy
+
+Themes control the overall color palette, font usage, and background texture for a given scene or set of scenes.
+
+Each theme is defined in JSON like:
+
+```json
+{
+  "id": "earthy-minimal",
+  "font": "Inter",
+  "colors": {
+    "background": "#f5f0e6",
+    "textPrimary": "#2e2b29",
+    "accent": "#a67c52"
+  },
+  "texture": "grunge-light.svg"
+}
+```
+
+These can be toggled at render time via the scene JSON:
+
+```json
+{
+  "type": "hero",
+  "theme": "earthy-minimal",
+  ...
+}
+```
+
+---
+
+## 🖋 Fonts
+
+All fonts are either:
+
+* Pulled from Google Fonts (with fallback CDN)
+* Available locally inside `/assets/fonts`
+
+Suggested fonts:
+
+* Inter (default)
+* DM Sans
+* Playfair Display (for contrasty scenes)
+
+---
+
+## 🧵 Background Textures
+
+Patterns or grunge overlays are applied as background SVGs, referenced by filename. These live in:
+
+```
+/public/assets/textures/
+```
+
+Examples:
+
+* `grunge-light.svg`
+* `paper-folded.svg`
+* `grid-dark.svg`
+* `noise-subtle.svg`
+
+Use in scene:
+
+```json
+{
+  "backgroundTexture": "paper-folded.svg"
+}
+```
+
+---
+
+## 🧱 Component Styling Philosophy
+
+We use Tailwind for all layout and color classes.
+Each component reads from the theme JSON to apply styling dynamically.
+
+Colors, fonts, and even corner radius or padding can vary by theme.
+
+This allows:
+
+* Flexible but consistent mood per scene
+* Reuse of core layout components
+* Future GPTs to apply visual styling via simple theme IDs
+
+---
+
+## 📁 Directory Layout
+
+```
+/public/assets/fonts/
+/public/assets/textures/
+/src/styles/themes.ts  ← theme registry
+```
+
+The `themes.ts` file exports a map of themes that UI components can reference dynamically.
+
+Example:
+
+```ts
+export const themes = {
+  "earthy-minimal": {
+    font: "Inter",
+    colors: { ... },
+    texture: "grunge-light.svg"
+  },
+  ...
+}
+```
+
+---
+
+Let’s lock this as our design guide. Next: want to move on to `EXAMPLES.md` for scene JSONs?


### PR DESCRIPTION
## Summary
- document hero, side-by-side, quote, gallery, and feature list scenes
- describe theme strategy, fonts, and textures in VISUALS guide
- add example JSON configs and schema reference

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895f49f15e0832ab6a0d1bafd12c955