### PR TITLE
refactor: centralize NotionDashboard scene type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,25 +5,9 @@ import addFormats from 'ajv-formats';
 // Import the component and the local JSON files
 import NotionDashboard from './components/NotionDashboard';
 import notionDashboardSchema from '../schemas/notionDashboard.schema.json';
+import type { NotionDashboardScene } from './types/notionDashboard';
 
-// Define the shape of our scene data
-interface NotionDashboardSceneData {
-  type: 'notionDashboard';
-  mainHeading: string;
-  subHeading: string;
-  browserUrl: string;
-  dashboardTitle: string;
-  sections: Array<{
-    title: string;
-    emoji: string;
-    items: Array<{
-      text: string;
-      checked: boolean;
-    }>;
-  }>;
-}
-
-type SceneData = NotionDashboardSceneData;
+type SceneData = NotionDashboardScene;
 
 function App() {
   const [sceneData, setSceneData] = useState<SceneData | null>(null);

--- a/src/components/NotionDashboard.tsx
+++ b/src/components/NotionDashboard.tsx
@@ -1,23 +1,8 @@
 import React from 'react';
-
-interface SceneData {
-  type: 'notionDashboard';
-  mainHeading: string;
-  subHeading: string;
-  browserUrl: string;
-  dashboardTitle: string;
-  sections: Array<{
-    title: string;
-    emoji: string;
-    items: Array<{
-      text: string;
-      checked: boolean;
-    }>;
-  }>;
-}
+import type { NotionDashboardScene } from '../types/notionDashboard';
 
 interface NotionDashboardProps {
-  scene: SceneData;
+  scene: NotionDashboardScene;
 }
 
 const NotionDashboard: React.FC<NotionDashboardProps> = ({ scene }) => {

--- a/src/types/notionDashboard.ts
+++ b/src/types/notionDashboard.ts
@@ -1,0 +1,15 @@
+export interface NotionDashboardScene {
+  type: 'notionDashboard';
+  mainHeading: string;
+  subHeading: string;
+  browserUrl: string;
+  dashboardTitle: string;
+  sections: Array<{
+    title: string;
+    emoji: string;
+    items: Array<{
+      text: string;
+      checked: boolean;
+    }>;
+  }>;
+}


### PR DESCRIPTION
## Summary
- share NotionDashboard scene interface via `src/types/notionDashboard.ts`
- consume shared type in `App` and `NotionDashboard` components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895f8943b84832a95ebaf600e34cada