### PR TITLE
Support multi-step scene overrides and captions

### DIFF
--- a/assets/css/mockup.css
+++ b/assets/css/mockup.css
@@ -115,8 +115,7 @@
   display: none; /* Hidden by default unless screenshot is injected */
   width: 100%;
   height: auto;
-  border-bottom-left-radius: var(--radius-frame);
-  border-bottom-right-radius: var(--radius-frame);
+  border-radius: var(--radius-frame);
 }
 .scene-container + .browser-screenshot { display: none; }
 [data-has-screenshot="true"] .browser-screenshot { display: block; }
@@ -156,6 +155,7 @@
 }
 .screenshot-grid .browser-screenshot {
   display: none;
+  border-radius: var(--radius-card);
 }
 [data-has-screenshot-left="true"] .screenshot-grid .browser-screenshot.left { display: block; }
 [data-has-screenshot-right="true"] .screenshot-grid .browser-screenshot.right { display: block; }
@@ -167,17 +167,21 @@
   gap: 10px;
   margin-top: 8px;
 }
+[data-has-screenshot-1="true"]:not([data-has-screenshot-2]):not([data-has-screenshot-3]):not([data-has-screenshot-4]) .howto-grid {
+  grid-template-columns: 1fr;
+}
 .howto-item {
   background: rgba(255,255,255,0.7);
   border: 1px solid rgba(0,0,0,0.06);
   border-radius: var(--radius-card);
   padding: 8px;
+  width: auto;
 }
 .howto-item .browser-screenshot {
   display: block;
   width: 100%;
   height: auto;
-  border-radius: 10px; /* rounded on all corners */
+  border-radius: var(--radius-card); /* rounded on all corners */
   box-shadow: var(--shadow-soft);
 }
 .step-label {

--- a/scenes/02-feature-variation-1.html
+++ b/scenes/02-feature-variation-1.html
@@ -34,7 +34,7 @@
             <h2 class="page-title">How To Use</h2>
           </header>
           <div class="howto-grid">
-            <div class="howto-item" style="grid-column: 1 / -1;">
+            <div class="howto-item">
               <img class="browser-screenshot" data-key="browserScreenshot1" src="../assets/screenshots/placeholder.png" alt="Step 1 screenshot" />
               <div class="step-label" data-key="stepLabel1">Step</div>
               <div class="step-text" data-key="stepText1">Short instruction goes here</div>

--- a/scenes/02-feature-variation-2.json
+++ b/scenes/02-feature-variation-2.json
@@ -1,0 +1,12 @@
+{
+  "theme": "purple",
+  "addressBar": "example.com",
+  "mainHeading": "Make progress visible",
+  "subHeading": "A simple system that rewards steady wins",
+  "browserScreenshot1": "../assets/screenshots/placeholder.png",
+  "stepLabel1": "Step",
+  "stepText1": "Short instruction goes here",
+  "browserScreenshot2": "../assets/screenshots/placeholder.png",
+  "stepLabel2": "Step",
+  "stepText2": "Short instruction goes here"
+}

--- a/scenes/02-feature-variation-3.json
+++ b/scenes/02-feature-variation-3.json
@@ -1,0 +1,15 @@
+{
+  "theme": "purple",
+  "addressBar": "example.com",
+  "mainHeading": "Make progress visible",
+  "subHeading": "A simple system that rewards steady wins",
+  "browserScreenshot1": "../assets/screenshots/placeholder.png",
+  "stepLabel1": "Step",
+  "stepText1": "Short instruction goes here",
+  "browserScreenshot2": "../assets/screenshots/placeholder.png",
+  "stepLabel2": "Step",
+  "stepText2": "Short instruction goes here",
+  "browserScreenshot3": "../assets/screenshots/placeholder.png",
+  "stepLabel3": "Step",
+  "stepText3": "Short instruction goes here"
+}

--- a/scenes/02-feature.html
+++ b/scenes/02-feature.html
@@ -44,9 +44,17 @@
             <div class="page-icon">✨</div>
             <h2 class="page-title">Feature Spotlight</h2>
           </header>
-          <div class="screenshot-grid">
-            <img class="browser-screenshot left" data-key="browserScreenshotLeft" src="../assets/screenshots/placeholder.png" alt="Left screenshot placeholder" />
-            <img class="browser-screenshot right" data-key="browserScreenshotRight" src="../assets/screenshots/placeholder.png" alt="Right screenshot placeholder" />
+          <div class="howto-grid">
+            <div class="howto-item">
+              <img class="browser-screenshot" data-key="browserScreenshot1" src="../assets/screenshots/placeholder.png" alt="Step 1 screenshot" />
+              <div class="step-label" data-key="stepLabel1">Step</div>
+              <div class="step-text" data-key="stepText1">Short instruction goes here</div>
+            </div>
+            <div class="howto-item">
+              <img class="browser-screenshot" data-key="browserScreenshot2" src="../assets/screenshots/placeholder.png" alt="Step 2 screenshot" />
+              <div class="step-label" data-key="stepLabel2">Step</div>
+              <div class="step-text" data-key="stepText2">Short instruction goes here</div>
+            </div>
           </div>
         </div>
       </div>

--- a/scenes/02-feature.json
+++ b/scenes/02-feature.json
@@ -1,7 +1,12 @@
 {
   "theme": "purple",
   "addressBar": "mondaychick.co",
-  "browserScreenshot": "../assets/screenshots/placeholder.png",
+  "browserScreenshot1": "../assets/screenshots/placeholder.png",
+  "browserScreenshot2": "../assets/screenshots/placeholder.png",
+  "stepLabel1": "Step",
+  "stepText1": "Short instruction goes here",
+  "stepLabel2": "Step",
+  "stepText2": "Short instruction goes here",
   "mainHeading": "Make progress visible",
   "subHeading": "A simple system that rewards steady wins"
 }

--- a/scripts/buildSceneHtml.js
+++ b/scripts/buildSceneHtml.js
@@ -99,9 +99,17 @@ function buildSceneHtml({ repoRoot, sceneHtmlPath, controllers, sceneJsonPath, o
         html = html.replace(labelRe, (_, a, _b, c) => `${a}${htmlEscape(data[labelKey])}${c}`);
       }
       const textKey = `stepText${i}`;
-      if (data[textKey]) {
+      if (Object.prototype.hasOwnProperty.call(data, textKey)) {
         const textRe = new RegExp(`(<[^>]*data-key=\"${textKey}\"[^>]*>)([\s\S]*?)(<\/[^>]+>)`);
-        html = html.replace(textRe, (_, a, _b, c) => `${a}${htmlEscape(data[textKey])}${c}`);
+        html = html.replace(textRe, (_, a, _b, c) => `${a}${htmlEscape(data[textKey] || '')}${c}`);
+      }
+    }
+    // Ensure explicit overrides for step text are applied
+    for (let i = 1; i <= 4; i++) {
+      const key = `stepText${i}`;
+      if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+        const textRe = new RegExp(`(<[^>]*data-key=\"${key}\"[^>]*>)([\s\S]*?)(<\/[^>]+>)`);
+        html = html.replace(textRe, (_, a, _b, c) => `${a}${htmlEscape(overrides[key] || '')}${c}`);
       }
     }
     // Toggle single screenshot visibility flag on <body> when not using placeholder

--- a/server.js
+++ b/server.js
@@ -43,6 +43,14 @@ app.get('/api/compose', (req, res) => {
     theme: req.query.background,
     themeColor: req.query.bgcolor,
   };
+  for (let i = 1; i <= 4; i++) {
+    const bs = req.query[`browserScreenshot${i}`];
+    const sl = req.query[`stepLabel${i}`];
+    const st = req.query[`stepText${i}`];
+    if (bs) controllers[`browserScreenshot${i}`] = bs;
+    if (sl) controllers[`stepLabel${i}`] = sl;
+    if (st) controllers[`stepText${i}`] = st;
+  }
   const html = buildSceneHtml({ repoRoot: REPO_ROOT, sceneHtmlPath: scene, controllers });
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.send(html);
@@ -65,7 +73,28 @@ app.post('/api/compose', (req, res) => {
       theme: body.theme || body.background,
       themeColor: body.themeColor || body.bgcolor,
     };
-    const html = buildSceneHtml({ sceneJsonPath: sceneJson, overrides });
+    for (let i = 1; i <= 4; i++) {
+      const bs = body[`browserScreenshot${i}`];
+      const sl = body[`stepLabel${i}`];
+      const st = body[`stepText${i}`];
+      if (bs) overrides[`browserScreenshot${i}`] = bs;
+      if (sl) overrides[`stepLabel${i}`] = sl;
+      if (st) overrides[`stepText${i}`] = st;
+    }
+    Object.keys(overrides).forEach((k) => overrides[k] == null && delete overrides[k]);
+    let html = buildSceneHtml({ sceneJsonPath: sceneJson, overrides });
+    for (let i = 1; i <= 4; i++) {
+      const label = body[`stepLabel${i}`];
+      if (label) {
+        const re = new RegExp(`(<[^>]*data-key=\"stepLabel${i}\"[^>]*>)([\\s\\S]*?)(<\/[^>]+>)`);
+        html = html.replace(re, (_, a, _b, c) => `${a}${label}${c}`);
+      }
+      const text = body[`stepText${i}`];
+      if (text) {
+        const re = new RegExp(`(<[^>]*data-key=\"stepText${i}\"[^>]*>)([\\s\\S]*?)(<\/[^>]+>)`);
+        html = html.replace(re, (_, a, _b, c) => `${a}${text}${c}`);
+      }
+    }
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     return res.send(html);
   }
@@ -80,6 +109,14 @@ app.post('/api/compose', (req, res) => {
     theme: body.background,
     themeColor: body.bgcolor,
   };
+  for (let i = 1; i <= 4; i++) {
+    const bs = body[`browserScreenshot${i}`];
+    const sl = body[`stepLabel${i}`];
+    const st = body[`stepText${i}`];
+    if (bs) controllers[`browserScreenshot${i}`] = bs;
+    if (sl) controllers[`stepLabel${i}`] = sl;
+    if (st) controllers[`stepText${i}`] = st;
+  }
   const html = buildSceneHtml({ repoRoot: REPO_ROOT, sceneHtmlPath: scene, controllers });
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.send(html);

--- a/tools/scene-02-builder.html
+++ b/tools/scene-02-builder.html
@@ -24,20 +24,36 @@
           <input type="text" id="subtitle" placeholder="Concise, compelling subheading" value="A simple system that rewards steady wins">
         </div>
         <div class="field">
-          <label for="imageLeft">Left Screenshot (URL)</label>
-          <input type="text" id="imageLeft" placeholder="assets/screenshots/left.png">
+          <label for="image1">Step 1 Screenshot (URL)</label>
+          <input type="text" id="image1" placeholder="assets/screenshots/step1.png">
         </div>
         <div class="field">
-          <label for="imageFileLeft">Or pick a left screenshot file</label>
-          <input type="file" id="imageFileLeft" accept="image/*">
+          <label for="imageFile1">Or pick a step 1 file</label>
+          <input type="file" id="imageFile1" accept="image/*">
         </div>
         <div class="field">
-          <label for="imageRight">Right Screenshot (URL)</label>
-          <input type="text" id="imageRight" placeholder="assets/screenshots/right.png">
+          <label for="label1">Step 1 Label</label>
+          <input type="text" id="label1" placeholder="Step" value="Step">
         </div>
         <div class="field">
-          <label for="imageFileRight">Or pick a right screenshot file</label>
-          <input type="file" id="imageFileRight" accept="image/*">
+          <label for="text1">Step 1 Instruction</label>
+          <input type="text" id="text1" placeholder="Short instruction goes here">
+        </div>
+        <div class="field">
+          <label for="image2">Step 2 Screenshot (URL)</label>
+          <input type="text" id="image2" placeholder="assets/screenshots/step2.png">
+        </div>
+        <div class="field">
+          <label for="imageFile2">Or pick a step 2 file</label>
+          <input type="file" id="imageFile2" accept="image/*">
+        </div>
+        <div class="field">
+          <label for="label2">Step 2 Label</label>
+          <input type="text" id="label2" placeholder="Step" value="Step">
+        </div>
+        <div class="field">
+          <label for="text2">Step 2 Instruction</label>
+          <input type="text" id="text2" placeholder="Short instruction goes here">
         </div>
         <div class="actions">
           <button id="applyBtn" type="button">Apply</button>
@@ -54,11 +70,15 @@
           addressBar: (q('url').value||'').trim(),
           mainHeading: (q('title').value||'').trim(),
           subHeading: (q('subtitle').value||'').trim(),
-          browserScreenshotLeft: (q('imageLeft').value||'').trim(),
-          browserScreenshotRight: (q('imageRight').value||'').trim()
+          browserScreenshot1: (q('image1').value||'').trim(),
+          browserScreenshot2: (q('image2').value||'').trim(),
+          stepLabel1: (q('label1').value||'').trim(),
+          stepText1: (q('text1').value||'').trim(),
+          stepLabel2: (q('label2').value||'').trim(),
+          stepText2: (q('text2').value||'').trim()
         };
-        const fl=q('imageFileLeft')?.files?.[0]; if(fl){ try{ p.browserScreenshotLeft=await toDataURL(fl) }catch(e){} }
-        const fr=q('imageFileRight')?.files?.[0]; if(fr){ try{ p.browserScreenshotRight=await toDataURL(fr) }catch(e){} }
+        const f1=q('imageFile1')?.files?.[0]; if(f1){ try{ p.browserScreenshot1=await toDataURL(f1) }catch(e){} }
+        const f2=q('imageFile2')?.files?.[0]; if(f2){ try{ p.browserScreenshot2=await toDataURL(f2) }catch(e){} }
         return p;
       }
       q('applyBtn').addEventListener('click', async ()=>{

--- a/tools/scene-02-feature-variation-1-builder.html
+++ b/tools/scene-02-feature-variation-1-builder.html
@@ -35,6 +35,10 @@
           <label for="label1">Step 1 Label</label>
           <input type="text" id="label1" placeholder="Step" value="Step">
         </div>
+        <div class="field">
+          <label for="text1">Step 1 Instruction</label>
+          <input type="text" id="text1" placeholder="Short instruction goes here">
+        </div>
         <div class="actions">
           <button id="applyBtn" type="button">Apply</button>
           <a id="openScene" href="/scenes/02-feature-variation-1.html" target="_blank">Open Scene</a>
@@ -51,7 +55,8 @@
           mainHeading: (q('title').value||'').trim(),
           subHeading: (q('subtitle').value||'').trim(),
           browserScreenshot1: (q('image1').value||'').trim(),
-          stepLabel1: (q('label1').value||'').trim()
+          stepLabel1: (q('label1').value||'').trim(),
+          stepText1: (q('text1').value||'').trim()
         };
         const f=q('imageFile1')?.files?.[0]; if(f){ try{ p.browserScreenshot1=await toDataURL(f) }catch(e){} }
         return p;


### PR DESCRIPTION
## Summary
- extend scene builder to handle numbered screenshots and step captions
- add JSON configs for feature scene variations 2 and 3
- round screenshot corners and add responsive rules for single-step layouts

## Testing
- `node -e "console.log(require('./scripts/buildSceneHtml').buildSceneHtml({sceneJsonPath:'scenes/02-feature.json'}).slice(0,200))"`
- `npm test` (fails: Missing script: "test")
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"scene":"02-feature-variation-1","browserScreenshot1":"https://example.com/foo.png","stepText1":"Hello"}' http://localhost:3000/api/compose | rg 'step-text' -n -C1`
- `curl -s http://localhost:3000/api/scenes`

------
https://chatgpt.com/codex/tasks/task_e_6898ef2f7408832aad4a771a40c7cf53