### PR TITLE
Polish Scene 01 visuals with depth and fade-in

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -51,3 +51,14 @@ body::after {
     outline: 2px solid rgba(16,185,129,0.6);
     outline-offset: 2px;
 }
+
+/* Scene 01 background */
+body.scene-01 {
+    background: radial-gradient(circle at 50% 50%, #ffffff 0%, #e8eef5 100%);
+}
+
+@media (prefers-color-scheme: dark) {
+    body.scene-01 {
+        background: radial-gradient(circle at 50% 50%, #1e293b 0%, #0f172a 100%);
+    }
+}

--- a/assets/css/mockup.css
+++ b/assets/css/mockup.css
@@ -279,3 +279,73 @@
   text-align: center;
   max-width: 720px;
 }
+
+/* Scene 01 specific polish */
+.scene-01 .browser-mockup {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.8);
+  box-shadow: 0 40px 60px rgba(0,0,0,0.15), 0 12px 20px rgba(0,0,0,0.08);
+}
+
+.scene-01 .browser-mockup::before {
+  background: linear-gradient(180deg, rgba(255,255,255,0.5), rgba(255,255,255,0) 40%);
+}
+
+.scene-01 .screenshot-wrap {
+  border-radius: var(--radius-frame);
+  padding: 4px;
+  aspect-ratio: 16/9;
+  background: rgba(0,0,0,0.02);
+}
+
+.scene-01 .browser-screenshot {
+  border-radius: calc(var(--radius-frame) - 4px);
+  box-shadow: 0 16px 32px rgba(0,0,0,0.12), 0 8px 16px rgba(0,0,0,0.08);
+}
+
+.scene-01 .browser-screenshot.fade-in {
+  opacity: 0;
+  animation: scene01-fade-in 0.6s ease forwards;
+}
+
+@keyframes scene01-fade-in {
+  to { opacity: 1; }
+}
+
+.scene-01 .content-wrapper {
+  gap: 32px;
+}
+
+.scene-01 .heading-wrap {
+  gap: 16px;
+}
+
+.scene-01 .main-heading {
+  font-weight: 700;
+  color: var(--text-strong);
+  background: none;
+}
+
+.scene-01 .sub-heading {
+  font-weight: 300;
+  color: var(--text-muted);
+}
+
+@media (prefers-color-scheme: dark) {
+  .scene-01 .browser-mockup {
+    background: rgba(30,41,59,0.6);
+    border: 1px solid rgba(255,255,255,0.1);
+  }
+
+  .scene-01 .browser-mockup::before {
+    background: linear-gradient(180deg, rgba(255,255,255,0.1), rgba(255,255,255,0) 40%);
+  }
+
+  .scene-01 .main-heading {
+    color: #f8fafc;
+  }
+
+  .scene-01 .sub-heading {
+    color: #cbd5e1;
+  }
+}

--- a/scenes/01-thumbnail.html
+++ b/scenes/01-thumbnail.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../assets/css/theme.css">
     <link rel="stylesheet" href="../assets/css/mockup.css">
 </head>
-<body>
+<body class="scene-01">
     <div class="scene-container" data-key="themeColor">
 
         <!-- Theme selector -->
@@ -35,7 +35,7 @@
                 <!-- Screenshot area inside the browser frame (no mock UI) -->
                 <div class="screenshot-wrap">
                     <img
-                        class="browser-screenshot"
+                        class="browser-screenshot fade-in"
                         data-key="browserScreenshot"
                         src="../assets/screenshots/placeholder.png"
                         alt="Screenshot placeholder"


### PR DESCRIPTION
## Summary
- scope Scene 01 styling with a dedicated `scene-01` body class and radial background that supports light/dark modes
- refine the browser frame and screenshot presentation with layered shadows, rounded corners, and a smooth fade-in effect
- adjust typography spacing to give the heading more weight and the subheading a lighter tone

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899000a0eb8832ab8e405edc9e5ba45