### PR TITLE
refactor: extract builder links style

### DIFF
--- a/assets/css/builder.css
+++ b/assets/css/builder.css
@@ -7,6 +7,7 @@
 }
 .builder-title { font-size: 28px; color: #0f172a; margin-bottom: 6px; letter-spacing: -0.01em; }
 .builder-note { color: #475569; margin-bottom: 20px; }
+.builder-links { list-style: none; padding: 0; display: grid; gap: 8px; }
 
 .builder-form { display: grid; gap: 16px; }
 .field { display: grid; gap: 6px; }

--- a/server.js
+++ b/server.js
@@ -125,7 +125,9 @@ app.post('/api/compose', (req, res) => {
 
 // Default route: link to builder and example
 app.get('/', (req, res) => {
-  res.type('html').send(`<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Product Image Studio</title><link rel="stylesheet" href="/assets/css/builder.css"></head><body class="builder-page"><main class="builder-container"><h1 class="builder-title">Product Image Studio</h1><ul class="builder-note" style="list-style:none; padding:0; display:grid; gap:8px;"><li><a href="/tools/scene-01-builder.html">Scene 01 Builder (Single Screenshot)</a></li><li><a href="/tools/scene-02-builder.html">Scene 02 Builder (Feature Spotlight – Two Screenshots)</a></li><li><a href="/tools/scene-02-feature-variation-1-builder.html">Scene 02 Variation 1 Builder (How To Use – One Step)</a></li></ul></main></body></html>`);
+  res
+    .type('html')
+    .send(`<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Product Image Studio</title><link rel="stylesheet" href="/assets/css/builder.css"></head><body class="builder-page"><main class="builder-container"><h1 class="builder-title">Product Image Studio</h1><ul class="builder-note builder-links"><li><a href="/tools/scene-01-builder.html">Scene 01 Builder (Single Screenshot)</a></li><li><a href="/tools/scene-02-builder.html">Scene 02 Builder (Feature Spotlight – Two Screenshots)</a></li><li><a href="/tools/scene-02-feature-variation-1-builder.html">Scene 02 Variation 1 Builder (How To Use – One Step)</a></li></ul></main></body></html>`);
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- move list layout styles to new `.builder-links` class
- reference the class in the default route and drop the inline styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js` & `curl -s http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_689a35b33e40832a9cff8e17352ddae3