### PR TITLE
Refactor buildSceneHtml into shared helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node server.js",
     "dev": "node server.js",
     "load": "node scripts/loadScene.js",
-    "batch": "node scripts/batchRender.js"
+    "batch": "node scripts/batchRender.js",
+    "test": "node test/buildSceneHtml.test.js"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/buildSceneHtml.js
+++ b/scripts/buildSceneHtml.js
@@ -26,230 +26,160 @@ function renderSection(sec) {
   return `\n  <div class="dashboard-section">\n    <div class="section-header">\n      <span class="section-emoji">${htmlEscape(sec.emoji || '')}</span>\n      <span class="section-title">${htmlEscape(sec.title || '')}</span>\n    </div>\n    <div class="task-list">\n      ${tasks}\n    </div>\n    ${progress}\n  </div>`;
 }
 
-function buildSceneHtml({ repoRoot, sceneHtmlPath, controllers, sceneJsonPath, overrides = {} }) {
-  // Two modes supported for compatibility:
-  // - Legacy: { repoRoot, sceneHtmlPath, controllers }
-  // - New:    { sceneJsonPath }
-  if (sceneJsonPath) {
-    const jsonAbs = path.resolve(sceneJsonPath);
-    const sceneDir = path.dirname(jsonAbs);
-    const base = path.basename(jsonAbs).replace(/\.json$/, '');
-    const htmlPath = path.join(sceneDir, `${base}.html`);
+function replaceAddressBar(html, data) {
+  if (!Object.prototype.hasOwnProperty.call(data, 'addressBar')) return html;
+  return html.replace(
+    /(<input[^>]*data-key="addressBar"[^>]*value=")[^"]*(")/,
+    (_, a, b) => `${a}${htmlEscape(data.addressBar || '')}${b}`
+  );
+}
 
-    const data = { ...JSON.parse(fs.readFileSync(jsonAbs, 'utf-8')), ...overrides };
-    let html = fs.readFileSync(htmlPath, 'utf-8');
-
-    // addressBar
-    html = html.replace(
-      /(<input[^>]*data-key="addressBar"[^>]*value=")[^"]*(")/,
-      (_, a, b) => `${a}${htmlEscape(data.addressBar || '')}${b}`
-    );
-
-    // main/sub headings
-    html = html
-      .replace(
-        /(<h1[^>]*data-key="mainHeading"[^>]*>)([\s\S]*?)(<\/h1>)/,
-        (_, a, _b, c) => `${a}${htmlEscape(data.mainHeading || '')}${c}`
-      )
-      .replace(
-        /(<p[^>]*data-key="subHeading"[^>]*>)([\s\S]*?)(<\/p>)/,
-        (_, a, _b, c) => `${a}${htmlEscape(data.subHeading || '')}${c}`
-      );
-
-    // screenshot src (allow remote/data URLs or relative path)
-    const imgSrc = data.browserScreenshot || '../assets/screenshots/placeholder.png';
-    // Support single-screenshot scenes
-    html = html.replace(
-      /(<img[^>]*class="browser-screenshot"(?![^>]*\bleft\b)(?![^>]*\bright\b)[^>]*src=")[^"]*(")/,
-      (_, a, b) => `${a}${imgSrc}${b}`
-    );
-    // Support two-up scenes
-    if (data.browserScreenshotLeft) {
-      html = html.replace(
-        /(<img[^>]*data-key="browserScreenshotLeft"[^>]*src=")[^"]*(")/,
-        (_, a, b) => `${a}${data.browserScreenshotLeft}${b}`
-      );
-      if (!/data-has-screenshot-left=/.test(html) && !/placeholder\.png/.test(String(data.browserScreenshotLeft))) {
-        html = html.replace('<body', '<body data-has-screenshot-left="true"');
-      }
-    }
-    if (data.browserScreenshotRight) {
-      html = html.replace(
-        /(<img[^>]*data-key="browserScreenshotRight"[^>]*src=")[^"]*(")/,
-        (_, a, b) => `${a}${data.browserScreenshotRight}${b}`
-      );
-      if (!/data-has-screenshot-right=/.test(html) && !/placeholder\.png/.test(String(data.browserScreenshotRight))) {
-        html = html.replace('<body', '<body data-has-screenshot-right="true"');
-      }
-    }
-    // Support how-to scenes with up to four screenshots and labels
-    for (let i = 1; i <= 4; i++) {
-      const key = `browserScreenshot${i}`;
-      if (data[key]) {
-        const re = new RegExp(`(<img[^>]*data-key=\"${key}\"[^>]*src=\")[^\"]*(\")`);
-        html = html.replace(re, (_, a, b) => `${a}${data[key]}${b}`);
-        const flag = `data-has-screenshot-${i}`;
-        if (!new RegExp(flag).test(html) && !/placeholder\.png/.test(String(data[key]))) {
-          html = html.replace('<body', `<body ${flag}="true"`);
-        }
-      }
-      const labelKey = `stepLabel${i}`;
-      if (data[labelKey]) {
-        const labelRe = new RegExp(`(<[^>]*data-key=\"${labelKey}\"[^>]*>)([\s\S]*?)(<\/[^>]+>)`);
-        html = html.replace(labelRe, (_, a, _b, c) => `${a}${htmlEscape(data[labelKey])}${c}`);
-      }
-      const textKey = `stepText${i}`;
-      if (Object.prototype.hasOwnProperty.call(data, textKey)) {
-        const textRe = new RegExp(`(<[^>]*data-key=\"${textKey}\"[^>]*>)([\s\S]*?)(<\/[^>]+>)`);
-        html = html.replace(textRe, (_, a, _b, c) => `${a}${htmlEscape(data[textKey] || '')}${c}`);
-      }
-    }
-    // Ensure explicit overrides for step text are applied
-    for (let i = 1; i <= 4; i++) {
-      const key = `stepText${i}`;
-      if (Object.prototype.hasOwnProperty.call(overrides, key)) {
-        const textRe = new RegExp(`(<[^>]*data-key=\"${key}\"[^>]*>)([\s\S]*?)(<\/[^>]+>)`);
-        html = html.replace(textRe, (_, a, _b, c) => `${a}${htmlEscape(overrides[key] || '')}${c}`);
-      }
-    }
-    // Toggle single screenshot visibility flag on <body> when not using placeholder
-    if (!/data-has-screenshot=/.test(html)) {
-      const isPlaceholder = /placeholder\.png(?:$|\?|#)/.test(String(imgSrc));
-      if (!isPlaceholder && !data.browserScreenshotLeft && !data.browserScreenshotRight) {
-        html = html.replace('<body', '<body data-has-screenshot="true"');
-      }
-    }
-
-    // theme (hook CSS with [data-theme="..."])
-    if (data.theme) html = html.replace('<body', `<body data-theme="${htmlEscape(data.theme)}"`);
-
-    // sections
-    const sectionsHtml = (data.sections || []).map((sec) => renderSection(sec)).join('\n');
-    html = html.replace(
-      /(<div[^>]*data-key="sections"[^>]*>)([\s\S]*?)(<\/div>)/,
-      (_, a, _b, c) => `${a}\n${sectionsHtml}\n${c}`
-    );
-
-    // Ensure a base href so relative assets resolve when opened via blob URLs
-    if (!/<base\s+href=/i.test(html)) {
-      html = html.replace(/<head(\s[^>]*)?>/i, (m) => `${m}<base href="/">`);
-    }
-    return html;
-  }
-
-  // Legacy compatibility path: use existing loader's algorithm
-  const repo = repoRoot || process.cwd();
-  const sceneAbs = path.resolve(repo, sceneHtmlPath);
-  const sceneDir = path.dirname(sceneAbs);
-  let html = fs.readFileSync(sceneAbs, 'utf-8');
-  const data = { ...(controllers || {}) };
-
-  // addressBar
-  if (Object.prototype.hasOwnProperty.call(data, 'addressBar')) {
-    html = html.replace(
-      /(<input[^>]*data-key="addressBar"[^>]*value=")[^"]*(")/,
-      (_, a, b) => `${a}${htmlEscape(data.addressBar || '')}${b}`
-    );
-  }
-  // headings
+function replaceHeadings(html, data) {
+  let out = html;
   if (Object.prototype.hasOwnProperty.call(data, 'mainHeading')) {
-    html = html.replace(
+    out = out.replace(
       /(<h1[^>]*data-key="mainHeading"[^>]*>)([\s\S]*?)(<\/h1>)/,
       (_, a, _b, c) => `${a}${htmlEscape(data.mainHeading || '')}${c}`
     );
   }
   if (Object.prototype.hasOwnProperty.call(data, 'subHeading')) {
-    html = html.replace(
+    out = out.replace(
       /(<p[^>]*data-key="subHeading"[^>]*>)([\s\S]*?)(<\/p>)/,
       (_, a, _b, c) => `${a}${htmlEscape(data.subHeading || '')}${c}`
     );
   }
-  // brand icon
-  if (Object.prototype.hasOwnProperty.call(data, 'brandIcon')) {
-    html = html.replace(
-      /(<img[^>]*data-key="brandIcon"[^>]*src=")[^"]*(")/,
-      (_, a, b) => `${a}${data.brandIcon}${b}`
-    );
-  }
-  // screenshot (legacy single)
-  if (Object.prototype.hasOwnProperty.call(data, 'browserScreenshot')) {
-    html = html.replace(
-      /(<img[^>]*class="browser-screenshot"(?![^>]*\bleft\b)(?![^>]*\bright\b)[^>]*src=")[^"]*(")/,
-      (_, a, b) => `${a}${data.browserScreenshot}${b}`
-    );
-    if (!/data-has-screenshot=/.test(html)) {
-      const isPlaceholder = /placeholder\.png(?:$|\?|#)/.test(String(data.browserScreenshot));
-      if (!isPlaceholder) {
-        html = html.replace('<body', '<body data-has-screenshot="true"');
-      }
-    }
-  }
-  // two-up legacy keys
-  if (Object.prototype.hasOwnProperty.call(data, 'browserScreenshotLeft')) {
-    html = html.replace(
+  return out;
+}
+
+function replaceBrandIcon(html, data) {
+  if (!Object.prototype.hasOwnProperty.call(data, 'brandIcon')) return html;
+  return html.replace(
+    /(<img[^>]*data-key="brandIcon"[^>]*src=")[^"]*(")/,
+    (_, a, b) => `${a}${data.brandIcon}${b}`
+  );
+}
+
+function replaceScreenshots(html, data, overrides = {}) {
+  let out = html;
+
+  const imgSrc = data.browserScreenshot || '../assets/screenshots/placeholder.png';
+  out = out.replace(
+    /(<img[^>]*class="browser-screenshot"(?![^>]*\bleft\b)(?![^>]*\bright\b)[^>]*src=")[^"]*(")/,
+    (_, a, b) => `${a}${imgSrc}${b}`
+  );
+
+  if (data.browserScreenshotLeft) {
+    out = out.replace(
       /(<img[^>]*data-key="browserScreenshotLeft"[^>]*src=")[^"]*(")/,
       (_, a, b) => `${a}${data.browserScreenshotLeft}${b}`
     );
-    if (!/data-has-screenshot-left=/.test(html)) {
-      const isPlaceholder = /placeholder\.png(?:$|\?|#)/.test(String(data.browserScreenshotLeft));
-      if (!isPlaceholder) {
-        html = html.replace('<body', '<body data-has-screenshot-left="true"');
-      }
+    if (!/data-has-screenshot-left=/.test(out) && !/placeholder\.png/.test(String(data.browserScreenshotLeft))) {
+      out = out.replace('<body', '<body data-has-screenshot-left="true"');
     }
   }
-  if (Object.prototype.hasOwnProperty.call(data, 'browserScreenshotRight')) {
-    html = html.replace(
+
+  if (data.browserScreenshotRight) {
+    out = out.replace(
       /(<img[^>]*data-key="browserScreenshotRight"[^>]*src=")[^"]*(")/,
       (_, a, b) => `${a}${data.browserScreenshotRight}${b}`
     );
-    if (!/data-has-screenshot-right=/.test(html)) {
-      const isPlaceholder = /placeholder\.png(?:$|\?|#)/.test(String(data.browserScreenshotRight));
-      if (!isPlaceholder) {
-        html = html.replace('<body', '<body data-has-screenshot-right="true"');
-      }
+    if (!/data-has-screenshot-right=/.test(out) && !/placeholder\.png/.test(String(data.browserScreenshotRight))) {
+      out = out.replace('<body', '<body data-has-screenshot-right="true"');
     }
   }
-  // theme
-  if (Object.prototype.hasOwnProperty.call(data, 'theme')) {
-    html = html.replace('<body', `<body data-theme="${htmlEscape(data.theme)}"`);
-  }
-  // sections
-  if (Array.isArray(data.sections)) {
-    const sectionsHtml = data.sections.map((sec) => renderSection(sec)).join('\n');
-    html = html.replace(
-      /(<div[^>]*data-key="sections"[^>]*>)([\s\S]*?)(<\/div>)/,
-      (_, a, _b, c) => `${a}\n${sectionsHtml}\n${c}`
-    );
-  }
-  // how-to legacy: screenshots 1..4 and labels
+
   for (let i = 1; i <= 4; i++) {
     const key = `browserScreenshot${i}`;
-    if (Object.prototype.hasOwnProperty.call(data, key)) {
+    if (data[key]) {
       const re = new RegExp(`(<img[^>]*data-key=\"${key}\"[^>]*src=\")[^\"]*(\")`);
-      html = html.replace(re, (_, a, b) => `${a}${data[key]}${b}`);
+      out = out.replace(re, (_, a, b) => `${a}${data[key]}${b}`);
       const flag = `data-has-screenshot-${i}`;
-      const isPlaceholder = /placeholder\.png(?:$|\?|#)/.test(String(data[key]));
-      if (!new RegExp(flag).test(html) && !isPlaceholder) {
-        html = html.replace('<body', `<body ${flag}="true"`);
+      if (!new RegExp(flag).test(out) && !/placeholder\.png/.test(String(data[key]))) {
+        out = out.replace('<body', `<body ${flag}="true"`);
       }
     }
     const labelKey = `stepLabel${i}`;
-    if (Object.prototype.hasOwnProperty.call(data, labelKey)) {
+    if (data[labelKey]) {
       const labelRe = new RegExp(`(<[^>]*data-key=\"${labelKey}\"[^>]*>)([\s\S]*?)(<\/[^>]+>)`);
-      html = html.replace(labelRe, (_, a, _b, c) => `${a}${htmlEscape(data[labelKey])}${c}`);
+      out = out.replace(labelRe, (_, a, _b, c) => `${a}${htmlEscape(data[labelKey])}${c}`);
     }
     const textKey = `stepText${i}`;
     if (Object.prototype.hasOwnProperty.call(data, textKey)) {
       const textRe = new RegExp(`(<[^>]*data-key=\"${textKey}\"[^>]*>)([\s\S]*?)(<\/[^>]+>)`);
-      html = html.replace(textRe, (_, a, _b, c) => `${a}${htmlEscape(data[textKey])}${c}`);
+      out = out.replace(textRe, (_, a, _b, c) => `${a}${htmlEscape(data[textKey] || '')}${c}`);
     }
   }
 
-  // Ensure a base href so relative assets resolve when opened via blob URLs
-  if (!/<base\s+href=/i.test(html)) {
-    html = html.replace(/<head(\s[^>]*)?>/i, (m) => `${m}<base href="/">`);
+  for (let i = 1; i <= 4; i++) {
+    const key = `stepText${i}`;
+    if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+      const textRe = new RegExp(`(<[^>]*data-key=\"${key}\"[^>]*>)([\s\S]*?)(<\/[^>]+>)`);
+      out = out.replace(textRe, (_, a, _b, c) => `${a}${htmlEscape(overrides[key] || '')}${c}`);
+    }
   }
-  return html;
+
+  if (!/data-has-screenshot=/.test(out)) {
+    const isPlaceholder = /placeholder\.png(?:$|\?|#)/.test(String(imgSrc));
+    if (!isPlaceholder && !data.browserScreenshotLeft && !data.browserScreenshotRight) {
+      out = out.replace('<body', '<body data-has-screenshot="true"');
+    }
+  }
+
+  return out;
+}
+
+function replaceTheme(html, data) {
+  if (!Object.prototype.hasOwnProperty.call(data, 'theme')) return html;
+  return html.replace('<body', `<body data-theme="${htmlEscape(data.theme)}"`);
+}
+
+function replaceSections(html, data) {
+  if (!Array.isArray(data.sections)) return html;
+  const sectionsHtml = data.sections.map((sec) => renderSection(sec)).join('\n');
+  return html.replace(
+    /(<div[^>]*data-key="sections"[^>]*>)([\s\S]*?)(<\/div>)/,
+    (_, a, _b, c) => `${a}\n${sectionsHtml}\n${c}`
+  );
+}
+
+function ensureBaseHref(html) {
+  if (/<base\s+href=/i.test(html)) return html;
+  return html.replace(/<head(\s[^>]*)?>/i, (m) => `${m}<base href="/">`);
+}
+
+function applyReplacements(html, data, overrides) {
+  let out = html;
+  out = replaceAddressBar(out, data);
+  out = replaceHeadings(out, data);
+  out = replaceBrandIcon(out, data);
+  out = replaceScreenshots(out, data, overrides);
+  out = replaceTheme(out, data);
+  out = replaceSections(out, data);
+  out = ensureBaseHref(out);
+  return out;
+}
+
+function loadInputs({ repoRoot, sceneHtmlPath, controllers, sceneJsonPath }) {
+  if (sceneJsonPath) {
+    const jsonAbs = path.resolve(sceneJsonPath);
+    const base = path.basename(jsonAbs).replace(/\.json$/, '');
+    const htmlPath = path.join(path.dirname(jsonAbs), `${base}.html`);
+    const data = JSON.parse(fs.readFileSync(jsonAbs, 'utf-8'));
+    const html = fs.readFileSync(htmlPath, 'utf-8');
+    return { html, data };
+    }
+  const repo = repoRoot || process.cwd();
+  const sceneAbs = path.resolve(repo, sceneHtmlPath);
+  const html = fs.readFileSync(sceneAbs, 'utf-8');
+  const data = { ...(controllers || {}) };
+  return { html, data };
+}
+
+function buildSceneHtml({ repoRoot, sceneHtmlPath, controllers, sceneJsonPath, overrides = {} }) {
+  const { html, data } = loadInputs({ repoRoot, sceneHtmlPath, controllers, sceneJsonPath });
+  const merged = { ...data, ...overrides };
+  return applyReplacements(html, merged, overrides);
 }
 
 module.exports = { buildSceneHtml };
+

--- a/test/buildSceneHtml.test.js
+++ b/test/buildSceneHtml.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const { buildSceneHtml } = require('../scripts/buildSceneHtml');
+
+const repoRoot = path.resolve(__dirname, '..');
+const sceneJson = path.join(repoRoot, 'scenes/01-thumbnail.json');
+
+const htmlFromJson = buildSceneHtml({ sceneJsonPath: sceneJson });
+
+const controllers = JSON.parse(fs.readFileSync(sceneJson, 'utf-8'));
+const htmlFromControllers = buildSceneHtml({
+  repoRoot,
+  sceneHtmlPath: 'scenes/01-thumbnail.html',
+  controllers,
+});
+
+assert.strictEqual(htmlFromJson, htmlFromControllers);
+assert.ok(/value="example.com"/.test(htmlFromJson));
+
+console.log('buildSceneHtml tests passed');
+


### PR DESCRIPTION
## Summary
- centralize HTML replacements (address bar, headings, screenshots, sections) into reusable helpers
- unify JSON and controller inputs through a single buildSceneHtml wrapper
- add smoke test covering both JSON and controller modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a35bbd294832abf99c8003c723f43