### PR TITLE
feat: allow scene background overrides via CSS variables

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -10,7 +10,11 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-    background: 
+    /* Defaults preserved via fallbacks */
+    --bg-start: #ffffff;
+    --bg-end: #e8eef5;
+    --noise-opacity: 0.03;
+    background:
         radial-gradient(circle at 20% 80%, rgba(120, 220, 180, 0.3) 0%, transparent 50%),
         radial-gradient(circle at 80% 20%, rgba(255, 240, 120, 0.25) 0%, transparent 50%),
         linear-gradient(135deg, #f8fffe 0%, #f0f9f4 25%, #fef9f0 75%, #f8fffe 100%);
@@ -41,7 +45,8 @@ body::after {
     left: 0;
     width: 100%;
     height: 100%;
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.03'/%3E%3C/svg%3E");
+    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+    opacity: var(--noise-opacity, 0.03);
     pointer-events: none;
     z-index: 1;
 }
@@ -54,11 +59,11 @@ body::after {
 
 /* Scene 01 background */
 body.scene-01 {
-    background: radial-gradient(circle at 50% 50%, #ffffff 0%, #e8eef5 100%);
+    background: radial-gradient(circle at 50% 50%, var(--bg-start, #ffffff) 0%, var(--bg-end, #e8eef5) 100%);
 }
 
 @media (prefers-color-scheme: dark) {
     body.scene-01 {
-        background: radial-gradient(circle at 50% 50%, #1e293b 0%, #0f172a 100%);
+        background: radial-gradient(circle at 50% 50%, var(--bg-start, #1e293b) 0%, var(--bg-end, #0f172a) 100%);
     }
 }

--- a/server.js
+++ b/server.js
@@ -42,7 +42,23 @@ app.get('/api/scenes', (_req, res) => {
 app.get('/api/compose', (req, res) => {
   const scene = req.query.scene || 'scenes/01-thumbnail.html';
   const controllers = buildControllers(req.query);
-  const html = buildSceneHtml({ repoRoot: REPO_ROOT, sceneHtmlPath: scene, controllers });
+  let html = buildSceneHtml({ repoRoot: REPO_ROOT, sceneHtmlPath: scene, controllers });
+
+  // Optional background overrides via query
+  const bgStart = req.query.bgStart;
+  const bgEnd = req.query.bgEnd;
+  const noiseOpacity = req.query.noiseOpacity;
+  if (bgStart || bgEnd || noiseOpacity) {
+    const styleParts = [];
+    if (bgStart) styleParts.push(`--bg-start:${htmlEscape(bgStart)}`);
+    if (bgEnd) styleParts.push(`--bg-end:${htmlEscape(bgEnd)}`);
+    if (noiseOpacity) styleParts.push(`--noise-opacity:${htmlEscape(noiseOpacity)}`);
+    if (styleParts.length) {
+      const inline = styleParts.join(';');
+      html = html.replace('<body', `<body style="${inline}"`);
+    }
+  }
+
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.send(html);
 });
@@ -85,14 +101,37 @@ app.post('/api/compose', (req, res) => {
     // Combine controller-derived values with our alias map (alias wins)
     const overrides = { ...controllers, ...alias };
 
-    const html = buildSceneHtml({ sceneJsonPath: sceneJson, overrides });
+    let html = buildSceneHtml({ sceneJsonPath: sceneJson, overrides });
+    // Optional background overrides via POST
+    const { bgStart, bgEnd, noiseOpacity } = body;
+    if (bgStart || bgEnd || noiseOpacity) {
+      const styleParts = [];
+      if (bgStart) styleParts.push(`--bg-start:${htmlEscape(bgStart)}`);
+      if (bgEnd) styleParts.push(`--bg-end:${htmlEscape(bgEnd)}`);
+      if (noiseOpacity) styleParts.push(`--noise-opacity:${htmlEscape(noiseOpacity)}`);
+      if (styleParts.length) {
+        const inline = styleParts.join(';');
+        html = html.replace('<body', `<body style="${inline}"`);
+      }
+    }
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     return res.send(html);
   }
 
   // Fallback legacy path usage
   const scene = body.scene || 'scenes/01-thumbnail.html';
-  const html = buildSceneHtml({ repoRoot: REPO_ROOT, sceneHtmlPath: scene, controllers });
+  let html = buildSceneHtml({ repoRoot: REPO_ROOT, sceneHtmlPath: scene, controllers });
+  const { bgStart, bgEnd, noiseOpacity } = body;
+  if (bgStart || bgEnd || noiseOpacity) {
+    const styleParts = [];
+    if (bgStart) styleParts.push(`--bg-start:${htmlEscape(bgStart)}`);
+    if (bgEnd) styleParts.push(`--bg-end:${htmlEscape(bgEnd)}`);
+    if (noiseOpacity) styleParts.push(`--noise-opacity:${htmlEscape(noiseOpacity)}`);
+    if (styleParts.length) {
+      const inline = styleParts.join(';');
+      html = html.replace('<body', `<body style="${inline}"`);
+    }
+  }
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.send(html);
 });


### PR DESCRIPTION
## Summary
- add CSS variable hooks for scene background and noise overlay
- accept optional `bgStart`, `bgEnd`, and `noiseOpacity` params and inject them inline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a578a03e4832a86ddca783a0a0271