### PR TITLE
feat(scenes): normalize screenshot flags, polish feature & split layouts

### DIFF
--- a/assets/css/mockup.css
+++ b/assets/css/mockup.css
@@ -124,6 +124,18 @@
   display: block;
 }
 
+/* --- Shared utilities --- */
+.shot--bottom-radius{border-radius:0 0 var(--radius-frame,24px) var(--radius-frame,24px)}
+.shot--shadow{box-shadow:var(--shadow-soft,0 24px 48px rgba(0,0,0,.35))}
+.shot--fade{opacity:0;transition:opacity .35s ease}
+.shot--fade[data-visible="true"]{opacity:1}
+
+/* Split layout utility */
+.layout-split{display:flex;align-items:center;gap:40px}
+@media (max-width:768px){
+  .layout-split{flex-direction:column;gap:24px}
+}
+
 /* Subtle glass overlay on top edge of the screenshot */
 .screenshot-wrap {
   position: relative;
@@ -275,35 +287,36 @@
 }
 
 .scene-01 .browser-screenshot {
-  border-radius: 0 0 var(--radius-frame) var(--radius-frame);
   display: block;
   width: 100%;
   height: auto;
   object-fit: cover;
-  box-shadow: 0 24px 48px rgba(0,0,0,0.15), 0 12px 24px rgba(0,0,0,0.1);
-}
-
-.scene-01 .browser-screenshot.fade-in {
-  opacity: 0;
-  animation: scene01-fade-in 0.6s ease forwards;
 }
 
 /* Scene 02 specific polish */
-.scene-02 .browser-screenshot {
-  border-radius: var(--radius-card);
-  display: block;
-  width: 100%;
-  height: auto;
-  object-fit: cover;
-  box-shadow: 0 24px 48px rgba(0,0,0,0.15), 0 12px 24px rgba(0,0,0,0.1);
+.scene-02 .howto-grid{
+  width:92%;
+  margin:12px auto 0;
+  position:relative;
+  overflow:hidden;
+  border-bottom-left-radius:var(--radius-frame,24px);
+  border-bottom-right-radius:var(--radius-frame,24px);
 }
-
-/* Scene 03 split layout */
-.scene-03 .content-wrapper.split {
-  display: flex;
-  align-items: center;
-  gap: 40px;
+.scene-02 .howto-grid::before{
+  content:"";
+  position:absolute; inset:0 0 auto 0; height:96px;
+  background:linear-gradient(to bottom, rgba(0,0,0,.08), transparent);
+  pointer-events:none;
+  border-top-left-radius:inherit; border-top-right-radius:inherit;
 }
+.scene-02 .browser-screenshot{
+  display:block; width:100%; height:auto; object-fit:cover;
+  border-radius:0 0 var(--radius-frame,24px) var(--radius-frame,24px);
+  box-shadow:var(--shadow-soft,0 24px 48px rgba(0,0,0,.35));
+  opacity:0; transition:opacity .35s ease;
+}
+.scene-02 [data-visible="true"].browser-screenshot{opacity:1}
+.scene-02 .floating-orb,.scene-02 .orb-1,.scene-02 .orb-2{display:none!important}
 
 .scene-03 .text-column {
   flex: 1;
@@ -322,15 +335,15 @@
   margin-top: 4px;
 }
 
-@media (max-width: 768px) {
-  .scene-03 .content-wrapper.split {
-    flex-direction: column;
-  }
-}
+.scene-03 ul.bullet-list li:empty{display:none}
 
-@keyframes scene01-fade-in {
-  to { opacity: 1; }
+.scene-03 .browser-screenshot{
+  display:block; width:100%; height:auto; object-fit:cover;
+  border-radius:0 0 var(--radius-frame,24px) var(--radius-frame,24px);
+  box-shadow:var(--shadow-soft,0 24px 48px rgba(0,0,0,.35));
+  opacity:0; transition:opacity .35s ease;
 }
+.scene-03 [data-visible="true"].browser-screenshot{opacity:1}
 
 .scene-01 .heading-wrap { gap: 16px; }
 

--- a/scenes/01-thumbnail.html
+++ b/scenes/01-thumbnail.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../assets/css/theme.css">
     <link rel="stylesheet" href="../assets/css/mockup.css">
 </head>
-<body data-theme="green" data-has-screenshot="true" class="scene-01">
+<body data-theme="green" class="scene-01">
     <div class="scene-container" data-key="themeColor">
 
         <!-- Theme selector -->
@@ -35,7 +35,7 @@
                 <!-- Screenshot area inside the browser frame (no mock UI) -->
                 <div class="screenshot-wrap">
                     <img
-                        class="browser-screenshot fade-in" data-visible="true"
+                        class="browser-screenshot shot--bottom-radius shot--shadow shot--fade" data-visible="true"
                         data-key="browserScreenshot"
                         src="../assets/screenshots/Screenshot from 2025-08-06 14-56-38.png"
                         alt="Screenshot placeholder"

--- a/scenes/02-feature.html
+++ b/scenes/02-feature.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet" href="../assets/css/base.css" />
   <link rel="stylesheet" href="../assets/css/theme.css" />
   <link rel="stylesheet" href="../assets/css/mockup.css" />
- </head>
-<body data-theme="purple" data-has-screenshot="true" class="scene-02">
+</head>
+<body data-theme="purple" class="scene-02">
   <div class="scene-container">
 
     <!-- Theme dots (visual only) -->
@@ -44,14 +44,10 @@
             <div class="page-icon">✨</div>
             <h2 class="page-title">Feature Spotlight</h2>
           </header>
-          <div class="screenshot-wrap">
-            <div class="howto-grid">
-              <div class="howto-item">
-                <img class="browser-screenshot" data-key="browserScreenshot" src="../assets/screenshots/placeholder.png" alt="Step screenshot" />
-                <div class="step-label" data-key="stepLabel">Step</div>
-                <div class="step-text" data-key="stepText">Short instruction goes here</div>
-              </div>
-            </div>
+          <div class="howto-grid">
+            <img class="browser-screenshot shot--bottom-radius shot--shadow shot--fade" data-key="browserScreenshot" src="../assets/screenshots/placeholder.png" alt="Step screenshot" />
+            <div class="step-label" data-key="stepLabel">Step</div>
+            <div class="step-text" data-key="stepText">Short instruction goes here</div>
           </div>
         </div>
       </div>
@@ -63,9 +59,6 @@
 
     <!-- Standalone screenshot element not used in this scene -->
 
-    <!-- Orbs -->
-    <div class="floating-orb orb-1"></div>
-    <div class="floating-orb orb-2"></div>
   </div>
 </body>
 </html>

--- a/scenes/03-split.html
+++ b/scenes/03-split.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="../assets/css/theme.css" />
   <link rel="stylesheet" href="../assets/css/mockup.css" />
 </head>
-<body data-theme="green" data-has-screenshot="true" class="scene-03">
+<body data-theme="green" class="scene-03">
   <div class="scene-container">
 
     <!-- Theme dots -->
@@ -20,7 +20,7 @@
       </div>
     </div>
 
-    <div class="content-wrapper split">
+    <div class="content-wrapper split layout-split">
       <div class="text-column">
         <h1 class="main-heading" data-key="mainHeading">Main heading</h1>
         <p class="sub-heading" data-key="subHeading">Subheading</p>
@@ -47,7 +47,7 @@
           >
         </div>
         <div class="screenshot-wrap">
-          <img class="browser-screenshot" data-key="browserScreenshot" src="../assets/screenshots/placeholder.png" alt="Screenshot" />
+          <img class="browser-screenshot shot--bottom-radius shot--shadow shot--fade" data-key="browserScreenshot" src="../assets/screenshots/placeholder.png" alt="Screenshot" />
         </div>
       </div>
     </div>

--- a/scripts/buildSceneHtml.js
+++ b/scripts/buildSceneHtml.js
@@ -67,6 +67,15 @@ function replaceScreenshots(html, data, overrides = {}) {
     /(<img[^>]*class="[^"]*\bbrowser-screenshot\b[^"]*"(?![^>]*\bleft\b)(?![^>]*\bright\b)[^>]*src=")[^"]*(")/,
     (_, a, b) => `${a}${imgSrc}${b}`
   );
+  const isPlaceholder = /placeholder\.png(?:$|\?|#)/.test(String(imgSrc));
+  if (!/data-has-screenshot=/.test(out) && !isPlaceholder) {
+    out = out.replace('<body', '<body data-has-screenshot="true"');
+  }
+  // Ensure the main <img> becomes visible
+  out = out.replace(
+    /(<img[^>]*class="browser-screenshot"[^>]*)(>)/,
+    (m, a, b) => (/\bdata-visible=/.test(m) ? m : `${a} data-visible="true"${b}`)
+  );
 
   if (data.browserScreenshotLeft) {
     out = out.replace(
@@ -124,13 +133,6 @@ function replaceScreenshots(html, data, overrides = {}) {
     if (Object.prototype.hasOwnProperty.call(overrides, key)) {
       const textRe = new RegExp(`(<[^>]*data-key=\"${key}\"[^>]*>)([\s\S]*?)(<\/[^>]+>)`);
       out = out.replace(textRe, (_, a, _b, c) => `${a}${htmlEscape(overrides[key] || '')}${c}`);
-    }
-  }
-
-  if (!/data-has-screenshot=/.test(out)) {
-    const isPlaceholder = /placeholder\.png(?:$|\?|#)/.test(String(imgSrc));
-    if (!isPlaceholder && !data.browserScreenshotLeft && !data.browserScreenshotRight) {
-      out = out.replace('<body', '<body data-has-screenshot="true"');
     }
   }
 

--- a/tools/scene-02-builder.html
+++ b/tools/scene-02-builder.html
@@ -12,6 +12,10 @@
       <h1 class="builder-title">Scene 02 — Feature Spotlight</h1>
       <form class="builder-form" onsubmit="return false;">
         <div class="field">
+          <label for="theme">Theme</label>
+          <input type="text" id="theme" placeholder="green | yellow | purple" value="purple">
+        </div>
+        <div class="field">
           <label for="url">URL (address bar)</label>
           <input type="text" id="url" placeholder="example.com" value="example.com">
         </div>
@@ -54,6 +58,7 @@
           addressBar: (q('url').value||'').trim(),
           mainHeading: (q('title').value||'').trim(),
           subHeading: (q('subtitle').value||'').trim(),
+          theme: (q('theme').value||'').trim(),
           browserScreenshot: (q('image').value||'').trim(),
           stepLabel: (q('label').value||'').trim(),
           stepText: (q('text').value||'').trim()

--- a/tools/scene-03-split-builder.html
+++ b/tools/scene-03-split-builder.html
@@ -12,6 +12,10 @@
       <h1 class="builder-title">Scene 03 — Split Layout</h1>
       <form class="builder-form" onsubmit="return false;">
         <div class="field">
+          <label for="theme">Theme</label>
+          <input type="text" id="theme" placeholder="green | yellow | purple" value="green">
+        </div>
+        <div class="field">
           <label for="url">URL (address bar)</label>
           <input type="text" id="url" placeholder="example.com" value="example.com">
         </div>
@@ -61,6 +65,7 @@
           bullet1: (q('bullet1').value||'').trim(),
           bullet2: (q('bullet2').value||'').trim(),
           bullet3: (q('bullet3').value||'').trim(),
+          theme: (q('theme').value||'').trim(),
           browserScreenshot: (q('image').value||'').trim()
         };
         const f=q('imageFile')?.files?.[0]; if(f){ try{ p.browserScreenshot=await toDataURL(f) }catch(e){} }


### PR DESCRIPTION
## Summary
- add reusable screenshot radius/shadow/fade and layout-split utilities
- refactor Scenes 02 & 03 HTML/CSS, unify screenshot handling, drop hard-coded flags
- expose theme fields in scene builders and tighten screenshot injection logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a68691318832a8b7fe87a5215afb7