### PR TITLE
Add MIT license and reference in metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Product Image Studio contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ This project builds temporary HTML files and PNG screenshots from scene JSON fil
 
 The commands above write `.temp.html` files and corresponding `.png` images into `output/`, which is ignored in version control.
 
+## License
+
+Licensed under the [MIT License](LICENSE).
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Static scenes with server-side composition and screenshot endpoints.",
+  "license": "MIT",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
## Summary
- add MIT license file
- reference license in package.json
- document license in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a75cbc2b4832a9a364d64ddb9232f