### PR TITLE
Add integration tests and screenshot endpoint with path validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
         "express": "^4.19.2",
         "puppeteer": "^23.3.0"
       },
+      "devDependencies": {
+        "pngjs": "^7.0.0",
+        "supertest": "^6.3.3"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -36,6 +40,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -167,6 +194,13 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -178,6 +212,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/b4a": {
       "version": "1.6.7",
@@ -435,6 +476,29 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -469,6 +533,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -529,6 +600,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -553,6 +634,17 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -641,6 +733,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -817,6 +925,13 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -842,6 +957,39 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -986,6 +1134,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1472,6 +1636,16 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -1965,6 +2139,82 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/tar-fs": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "node server.js",
     "load": "node scripts/loadScene.js",
     "batch": "node scripts/batchRender.js",
-    "test": "node test/buildSceneHtml.test.js"
+    "test": "node test/buildSceneHtml.test.js && node test/api.test.js"
   },
   "engines": {
     "node": ">=18"
@@ -17,6 +17,10 @@
   "dependencies": {
     "express": "^4.19.2",
     "puppeteer": "^23.3.0"
+  },
+  "devDependencies": {
+    "pngjs": "^7.0.0",
+    "supertest": "^6.3.3"
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const express = require('express');
+const puppeteer = require('puppeteer');
 
 // Keep both exports available from buildSceneHtml; htmlEscape may be used by callers later.
 // eslint-disable-next-line no-unused-vars
@@ -10,6 +11,63 @@ const { buildControllers } = require('./scripts/buildControllers');
 const app = express();
 const PORT = process.env.PORT || 3000;
 const REPO_ROOT = process.cwd();
+
+function safeSceneBase(name) {
+  const base = (name || '').replace(/\.(html|json)$/i, '');
+  if (!base || base.includes('..') || /[\/]/.test(base)) return null;
+  return base;
+}
+
+function composeHtmlFromBody(body = {}) {
+  const baseInput = body.scene;
+  const base = baseInput ? safeSceneBase(baseInput) : '01-thumbnail';
+  if (!base) {
+    const err = new Error('invalid_scene');
+    err.code = 'INVALID_SCENE';
+    throw err;
+  }
+  const sceneJson = path.join(REPO_ROOT, 'scenes', `${base}.json`);
+  if (!fs.existsSync(sceneJson)) {
+    const err = new Error('scene_not_found');
+    err.code = 'SCENE_NOT_FOUND';
+    throw err;
+  }
+  const controllers = buildControllers(body);
+  const alias = {
+    addressBar: body.addressBar || body.url,
+    mainHeading: body.mainHeading || body.title,
+    subHeading: body.subHeading || body.subtitle,
+    brandIcon: body.brandIcon || body.icon,
+    browserScreenshot: body.browserScreenshot || body.image,
+    browserScreenshotLeft: body.browserScreenshotLeft || body.imageLeft,
+    browserScreenshotRight: body.browserScreenshotRight || body.imageRight,
+    theme: body.theme || body.background,
+    themeColor: body.themeColor || body.bgcolor,
+  };
+  for (let i = 1; i <= 4; i++) {
+    const bs = body[`browserScreenshot${i}`];
+    const sl = body[`stepLabel${i}`];
+    const st = body[`stepText${i}`];
+    if (bs) alias[`browserScreenshot${i}`] = bs;
+    if (sl) alias[`stepLabel${i}`] = sl;
+    if (st) alias[`stepText${i}`] = st;
+  }
+  Object.keys(alias).forEach((k) => alias[k] == null && delete alias[k]);
+  const overrides = { ...controllers, ...alias };
+  let html = buildSceneHtml({ sceneJsonPath: sceneJson, overrides });
+  const { bgStart, bgEnd, noiseOpacity } = body;
+  if (bgStart || bgEnd || noiseOpacity) {
+    const styleParts = [];
+    if (bgStart) styleParts.push(`--bg-start:${htmlEscape(bgStart)}`);
+    if (bgEnd) styleParts.push(`--bg-end:${htmlEscape(bgEnd)}`);
+    if (noiseOpacity) styleParts.push(`--noise-opacity:${htmlEscape(noiseOpacity)}`);
+    if (styleParts.length) {
+      const inline = styleParts.join(';');
+      html = html.replace('<body', `<body style="${inline}"`);
+    }
+  }
+  return html;
+}
 
 // Parse JSON bodies for POST endpoints
 app.use(express.json({ limit: '12mb' }));
@@ -41,8 +99,16 @@ app.get('/api/scenes', (_req, res) => {
 // Compose endpoint (GET): returns filled HTML based on query params
 app.get('/api/compose', (req, res) => {
   const scene = req.query.scene || 'scenes/01-thumbnail.html';
+  const abs = path.resolve(REPO_ROOT, scene);
+  const scenesDir = path.join(REPO_ROOT, 'scenes');
+  if (!abs.startsWith(scenesDir)) {
+    return res.status(400).json({ error: 'invalid_scene' });
+  }
+  if (!fs.existsSync(abs)) {
+    return res.status(404).json({ error: 'scene_not_found' });
+  }
   const controllers = buildControllers(req.query);
-  let html = buildSceneHtml({ repoRoot: REPO_ROOT, sceneHtmlPath: scene, controllers });
+  let html = buildSceneHtml({ sceneHtmlPath: abs, controllers });
 
   // Optional background overrides via query
   const bgStart = req.query.bgStart;
@@ -65,75 +131,44 @@ app.get('/api/compose', (req, res) => {
 
 // Compose endpoint (POST): supports scene base + overrides from body
 app.post('/api/compose', (req, res) => {
-  const body = req.body || {};
-  // Support new scene base usage: body.scene like '01-thumbnail'
-  const base = (body.scene || '').replace(/\.(html|json)$/i, '') || '01-thumbnail';
-  const sceneJson = path.join(REPO_ROOT, 'scenes', `${base}.json`);
-  const controllers = buildControllers(body);
-
-  if (fs.existsSync(sceneJson)) {
-    // Map common aliases from body → scene keys (non-destructive)
-    const alias = {
-      addressBar: body.addressBar || body.url,
-      mainHeading: body.mainHeading || body.title,
-      subHeading: body.subHeading || body.subtitle,
-      brandIcon: body.brandIcon || body.icon,
-      browserScreenshot: body.browserScreenshot || body.image,
-      browserScreenshotLeft: body.browserScreenshotLeft || body.imageLeft,
-      browserScreenshotRight: body.browserScreenshotRight || body.imageRight,
-      theme: body.theme || body.background,
-      themeColor: body.themeColor || body.bgcolor,
-    };
-
-    // Pass through numbered step fields if present
-    for (let i = 1; i <= 4; i++) {
-      const bs = body[`browserScreenshot${i}`];
-      const sl = body[`stepLabel${i}`];
-      const st = body[`stepText${i}`];
-      if (bs) alias[`browserScreenshot${i}`] = bs;
-      if (sl) alias[`stepLabel${i}`] = sl;
-      if (st) alias[`stepText${i}`] = st;
-    }
-
-    // Drop null/undefined so we don’t overwrite JSON defaults
-    Object.keys(alias).forEach((k) => alias[k] == null && delete alias[k]);
-
-    // Combine controller-derived values with our alias map (alias wins)
-    const overrides = { ...controllers, ...alias };
-
-    let html = buildSceneHtml({ sceneJsonPath: sceneJson, overrides });
-    // Optional background overrides via POST
-    const { bgStart, bgEnd, noiseOpacity } = body;
-    if (bgStart || bgEnd || noiseOpacity) {
-      const styleParts = [];
-      if (bgStart) styleParts.push(`--bg-start:${htmlEscape(bgStart)}`);
-      if (bgEnd) styleParts.push(`--bg-end:${htmlEscape(bgEnd)}`);
-      if (noiseOpacity) styleParts.push(`--noise-opacity:${htmlEscape(noiseOpacity)}`);
-      if (styleParts.length) {
-        const inline = styleParts.join(';');
-        html = html.replace('<body', `<body style="${inline}"`);
-      }
-    }
+  try {
+    const html = composeHtmlFromBody(req.body || {});
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
-    return res.send(html);
-  }
-
-  // Fallback legacy path usage
-  const scene = body.scene || 'scenes/01-thumbnail.html';
-  let html = buildSceneHtml({ repoRoot: REPO_ROOT, sceneHtmlPath: scene, controllers });
-  const { bgStart, bgEnd, noiseOpacity } = body;
-  if (bgStart || bgEnd || noiseOpacity) {
-    const styleParts = [];
-    if (bgStart) styleParts.push(`--bg-start:${htmlEscape(bgStart)}`);
-    if (bgEnd) styleParts.push(`--bg-end:${htmlEscape(bgEnd)}`);
-    if (noiseOpacity) styleParts.push(`--noise-opacity:${htmlEscape(noiseOpacity)}`);
-    if (styleParts.length) {
-      const inline = styleParts.join(';');
-      html = html.replace('<body', `<body style="${inline}"`);
+    res.send(html);
+  } catch (e) {
+    if (e.code === 'INVALID_SCENE') {
+      return res.status(400).json({ error: 'invalid_scene' });
     }
+    if (e.code === 'SCENE_NOT_FOUND') {
+      return res.status(404).json({ error: 'scene_not_found' });
+    }
+    res.status(500).json({ error: 'compose_failed', message: e.message });
   }
-  res.setHeader('Content-Type', 'text/html; charset=utf-8');
-  res.send(html);
+});
+
+app.post('/api/screenshot', async (req, res) => {
+  try {
+    const width = Number(req.body?.width) || 1600;
+    const height = Number(req.body?.height) || 900;
+    const html = composeHtmlFromBody(req.body || {});
+    const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+    const page = await browser.newPage();
+    await page.setViewport({ width, height });
+    await page.setContent(html, { waitUntil: 'networkidle0' });
+    const raw = await page.screenshot({ type: 'png' });
+    await browser.close();
+    const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
+    res.setHeader('Content-Type', 'image/png');
+    res.send(buf);
+  } catch (e) {
+    if (e.code === 'INVALID_SCENE') {
+      return res.status(400).json({ error: 'invalid_scene' });
+    }
+    if (e.code === 'SCENE_NOT_FOUND') {
+      return res.status(404).json({ error: 'scene_not_found' });
+    }
+    res.status(500).json({ error: 'screenshot_failed', message: e.message });
+  }
 });
 
 // Default route: index with links to per-scene builders
@@ -163,6 +198,10 @@ app.get('/', (_req, res) => {
     );
 });
 
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,62 @@
+const test = require('node:test');
+const assert = require('assert');
+const request = require('supertest');
+const { PNG } = require('pngjs');
+const app = require('../server');
+
+function binaryParser(res, callback) {
+  res.setEncoding('binary');
+  res.data = '';
+  res.on('data', (chunk) => { res.data += chunk; });
+  res.on('end', () => {
+    callback(null, Buffer.from(res.data, 'binary'));
+  });
+}
+
+test('GET /api/scenes returns list', async () => {
+  const res = await request(app).get('/api/scenes').expect(200);
+  assert.ok(Array.isArray(res.body.scenes));
+  assert.ok(res.body.scenes.includes('01-thumbnail'));
+});
+
+test('GET /api/compose rejects traversal', async () => {
+  await request(app)
+    .get('/api/compose?scene=../package.json')
+    .expect(400);
+});
+
+test('POST /api/compose renders HTML', async () => {
+  const res = await request(app)
+    .post('/api/compose')
+    .send({ scene: '01-thumbnail', mainHeading: 'Hello' })
+    .expect(200)
+    .expect('Content-Type', /html/);
+  assert.ok(/Hello/.test(res.text));
+});
+
+test('POST /api/compose rejects traversal', async () => {
+  await request(app)
+    .post('/api/compose')
+    .send({ scene: '../etc/passwd' })
+    .expect(400);
+});
+
+test('POST /api/screenshot returns PNG with size', async () => {
+  const res = await request(app)
+    .post('/api/screenshot')
+    .buffer(true)
+    .parse(binaryParser)
+    .send({ scene: '01-thumbnail', width: 200, height: 100 })
+    .expect(200)
+    .expect('Content-Type', /png/);
+  const png = PNG.sync.read(res.body);
+  assert.strictEqual(png.width, 200);
+  assert.strictEqual(png.height, 100);
+});
+
+test('POST /api/screenshot rejects traversal', async () => {
+  await request(app)
+    .post('/api/screenshot')
+    .send({ scene: '../etc/passwd' })
+    .expect(400);
+});


### PR DESCRIPTION
## Summary
- add integration tests for scenes, compose, and screenshot endpoints
- expose new `/api/screenshot` endpoint with size overrides
- harden compose endpoints against path traversal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a75c3a7ac832a900949191807b806