### PR TITLE
feat: add screenshot endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ This project builds temporary HTML files and PNG screenshots from scene JSON fil
 
 The commands above write `.temp.html` files and corresponding `.png` images into `output/`, which is ignored in version control.
 
+## API
+
+### `POST /api/screenshot`
+
+Generate a PNG from any scene. The request body mirrors the fields used by `/api/compose` and also accepts `width` and `height`:
+
+```sh
+curl -o out.png -X POST http://localhost:3000/api/screenshot \
+  -H "Content-Type: application/json" \
+  -d '{"scene":"01-thumbnail","width":1600,"height":900}'
+```
+
+The response has `Content-Type: image/png` and returns the raw image bytes.
+


### PR DESCRIPTION
## Summary
- add `/api/screenshot` route to build scenes and return PNGs via Puppeteer
- document screenshot API usage in README

## Testing
- `npm test`
- `curl -X POST http://localhost:3000/api/screenshot` *(fails: libatk-1.0.so.0 missing)*


------
https://chatgpt.com/codex/tasks/task_e_689a75add060832aaf04310912a68f3c