### PR TITLE
Remove automated screenshot endpoint

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,17 +1,7 @@
 const test = require('node:test');
 const assert = require('assert');
 const request = require('supertest');
-const { PNG } = require('pngjs');
 const app = require('../server');
-
-function binaryParser(res, callback) {
-  res.setEncoding('binary');
-  res.data = '';
-  res.on('data', (chunk) => { res.data += chunk; });
-  res.on('end', () => {
-    callback(null, Buffer.from(res.data, 'binary'));
-  });
-}
 
 test('GET /api/scenes returns list', async () => {
   const res = await request(app).get('/api/scenes').expect(200);
@@ -41,22 +31,3 @@ test('POST /api/compose rejects traversal', async () => {
     .expect(400);
 });
 
-test('POST /api/screenshot returns PNG with size', async () => {
-  const res = await request(app)
-    .post('/api/screenshot')
-    .buffer(true)
-    .parse(binaryParser)
-    .send({ scene: '01-thumbnail', width: 200, height: 100 })
-    .expect(200)
-    .expect('Content-Type', /png/);
-  const png = PNG.sync.read(res.body);
-  assert.strictEqual(png.width, 200);
-  assert.strictEqual(png.height, 100);
-});
-
-test('POST /api/screenshot rejects traversal', async () => {
-  await request(app)
-    .post('/api/screenshot')
-    .send({ scene: '../etc/passwd' })
-    .expect(400);
-});


### PR DESCRIPTION
## Summary
- strip Puppeteer import and screenshot endpoint
- adjust API tests after removing screenshot route

## Testing
- `npm test`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_689af2571a90832a8fd7dddcd3f7e83a