### PR TITLE
feat: parse comma separated fields in product form

### DIFF
--- a/app/components/ProductForm.tsx
+++ b/app/components/ProductForm.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+
+export type Product = {
+  id?: string;
+  name?: string;
+  features?: string[];
+  categories?: string[];
+  tags?: string[];
+  media?: string[];
+};
+
+export default function ProductForm({
+  initialProduct = {},
+  onSubmit,
+}: {
+  initialProduct?: Product;
+  onSubmit: (data: Product) => void;
+}) {
+  const [name, setName] = useState(initialProduct.name || "");
+  const [featureText, setFeatureText] = useState(
+    (initialProduct.features || []).join(", ")
+  );
+  const [categoryText, setCategoryText] = useState(
+    (initialProduct.categories || []).join(", ")
+  );
+  const [tagText, setTagText] = useState(
+    (initialProduct.tags || []).join(", ")
+  );
+  const [media, setMedia] = useState<string[]>(initialProduct.media || []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const features = featureText
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const categories = categoryText
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const tags = tagText
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const payload: Product = {
+      ...initialProduct,
+      name,
+      features,
+      categories,
+      tags,
+      media: media.length ? media : [],
+    };
+
+    onSubmit(payload);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Name"
+        className="border p-2"
+      />
+      <input
+        value={featureText}
+        onChange={(e) => setFeatureText(e.target.value)}
+        placeholder="Features (comma separated)"
+        className="border p-2"
+      />
+      <input
+        value={categoryText}
+        onChange={(e) => setCategoryText(e.target.value)}
+        placeholder="Categories (comma separated)"
+        className="border p-2"
+      />
+      <input
+        value={tagText}
+        onChange={(e) => setTagText(e.target.value)}
+        placeholder="Tags (comma separated)"
+        className="border p-2"
+      />
+      {/* In a full app a media uploader would update state here */}
+      <button type="submit" className="bg-blue-600 text-white p-2">
+        Save Product
+      </button>
+    </form>
+  );
+}
+

--- a/app/products/[id]/page.tsx
+++ b/app/products/[id]/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ProductForm, { Product } from "@/app/components/ProductForm";
+
+export default function EditProductPage({ params }: { params: { id: string } }) {
+  const [product, setProduct] = useState<Product | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/products/${params.id}`)
+      .then((res) => res.json())
+      .then((data) => setProduct(data));
+  }, [params.id]);
+
+  const handleUpdate = async (updated: Product) => {
+    await fetch(`/api/products/${params.id}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(updated),
+    });
+  };
+
+  if (!product) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <section className="p-4">
+      <h1 className="text-xl mb-4">Edit Product</h1>
+      <ProductForm initialProduct={product} onSubmit={handleUpdate} />
+    </section>
+  );
+}
+

--- a/app/products/new/page.tsx
+++ b/app/products/new/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import ProductForm from "@/app/components/ProductForm";
+
+export default function NewProductPage() {
+  const handleCreate = async (product: any) => {
+    await fetch("/api/products", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(product),
+    });
+  };
+
+  return (
+    <section className="p-4">
+      <h1 className="text-xl mb-4">New Product</h1>
+      <ProductForm onSubmit={handleCreate} />
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- allow comma-separated features, categories, and tags in product form
- ensure create and edit pages submit correct arrays and empty media fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b765f63fc832a87befb209096d7ea