### PR TITLE
feat: add auth gate

### DIFF
--- a/app/components/AuthGate.tsx
+++ b/app/components/AuthGate.tsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect, ReactNode } from 'react';
+
+interface AuthGateProps {
+  children: ReactNode;
+}
+
+export default function AuthGate({ children }: AuthGateProps) {
+  const [password, setPassword] = useState('');
+  const [authed, setAuthed] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('admin_pass');
+    if (stored === 'PaperMoon') {
+      setAuthed(true);
+    }
+  }, []);
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (password === 'PaperMoon') {
+      localStorage.setItem('admin_pass', 'PaperMoon');
+      setAuthed(true);
+    }
+  }
+
+  if (authed) {
+    return <>{children}</>;
+  }
+
+  return (
+    <form onSubmit={submit}>
+      <label>
+        Admin Password
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </label>
+      <button type="submit">Enter</button>
+    </form>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode } from 'react';
+import AuthGate from './components/AuthGate';
+
+interface RootLayoutProps {
+  children: ReactNode;
+}
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body>
+        <AuthGate>{children}</AuthGate>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- add AuthGate component with hardcoded PaperMoon password and localStorage persistence
- wrap app layout with AuthGate to protect admin pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7639fd4c832ab29751605f3bdad1